### PR TITLE
feat: add RDS instance and security group configuration

### DIFF
--- a/modules/aws/rds/variables.tf
+++ b/modules/aws/rds/variables.tf
@@ -67,3 +67,9 @@ variable "parameter_group_name" {
   description = "Parameter group name"
   type        = string
 }
+
+variable "public_subnet_ids" {
+  description = "List of public subnet IDs"
+  type        = list(string)
+  default     = []
+}

--- a/rds.tf
+++ b/rds.tf
@@ -1,0 +1,38 @@
+#######################################
+# Security Groups
+#######################################
+
+module "hackathon_rds_sg" {
+  source              = "./modules/aws/security_group"
+  vpc_id              = module.hackathon_vpc.vpc_id
+  ingress_port        = 5432
+  ingress_protocol    = "tcp"
+  ingress_cidr_blocks = ["0.0.0.0/0"]
+  name                = "${var.project_name}-rds-sg"
+}
+
+#######################################
+# RDS Instance
+#######################################
+
+module "hackathon_rds" {
+  source                 = "./modules/aws/rds"
+  identifier             = "hackathon"
+  engine                 = "postgres"
+  engine_version         = "16.3"
+  instance_class         = "db.t3.micro"
+  allocated_storage      = 10
+  username               = var.rds_username
+  password               = var.rds_password
+  publicly_accessible    = true
+  vpc_security_group_ids = [module.hackathon_rds_sg.security_group_id]
+  name                   = "${var.project_name}-rds"
+  subnet_group_name      = "${var.project_name}-subnet-group"
+  db_name                = var.rds_db_name
+  parameter_group_name   = "postgres16"
+
+  subnet_ids = [
+    module.hackathon_public_subnet_a.subnet_id,
+    module.hackathon_public_subnet_b.subnet_id
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -58,3 +58,18 @@ variable "backend_nlb_name" {
   description = "Name of the NLB for the backend service"
   type        = string
 }
+
+variable "rds_username" {
+  description = "Username for the RDS instance"
+  type        = string
+}
+
+variable "rds_password" {
+  description = "Password for the RDS instance"
+  type        = string
+}
+
+variable "rds_db_name" {
+  description = "Name of the RDS database"
+  type        = string
+}


### PR DESCRIPTION
This commit introduces a new RDS instance and its associated security group in `rds.tf`, enabling PostgreSQL database functionality for the application. The security group allows ingress on port 5432 from all IP addresses, while the RDS instance is configured with parameters such as instance class, storage, and database name. Additionally, new variables for RDS username, password, and database name are added in `variables.tf`, enhancing the configuration's flexibility and usability.