### PR TITLE
fix: update RDS parameter group name to use default value

### DIFF
--- a/modules/aws/rds/variables.tf
+++ b/modules/aws/rds/variables.tf
@@ -66,6 +66,7 @@ variable "engine_version" {
 variable "parameter_group_name" {
   description = "Parameter group name"
   type        = string
+  default     = "default.postgres16"
 }
 
 variable "public_subnet_ids" {

--- a/rds.tf
+++ b/rds.tf
@@ -29,7 +29,6 @@ module "hackathon_rds" {
   name                   = "${var.project_name}-rds"
   subnet_group_name      = "${var.project_name}-subnet-group"
   db_name                = var.rds_db_name
-  parameter_group_name   = "postgres16"
 
   subnet_ids = [
     module.hackathon_public_subnet_a.subnet_id,


### PR DESCRIPTION
This commit removes the hardcoded parameter group name "postgres16" from `rds.tf` and sets a default value for the `parameter_group_name` variable in `variables.tf`. This change enhances flexibility by allowing the use of a default parameter group while maintaining compatibility with existing configurations.